### PR TITLE
Remove an extra --tmpfs argument in "How to run it" documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The official image is based on CentOS, which is great an reliable to run service
 
 I highly recommend using tmpfs for storage as Docker is otherwise not very efficient; direct host network usage also helps with efficiency:
 
-> docker run --ulimit memlock=-1:-1 -ti --tmpfs /run --tmpfs=/opt/elasticsearch/volatile/data:uid=1000 --tmpfs --tmpfs=/opt/elasticsearch/volatile/logs:uid=1000 --net=host --name es-it sanne/elasticsearch-light-testing
+> docker run --ulimit memlock=-1:-1 -ti --tmpfs /run --tmpfs=/opt/elasticsearch/volatile/data:uid=1000 --tmpfs=/opt/elasticsearch/volatile/logs:uid=1000 --net=host --name es-it sanne/elasticsearch-light-testing
 
 Get rid of it after testing:
 
@@ -33,5 +33,5 @@ Build it locally:
 
 Don't forget to change `customtest` consistently in the run script:
 
-> docker run --ulimit memlock=-1:-1 -ti --tmpfs /run --tmpfs=/opt/elasticsearch/volatile/data:uid=1000 --tmpfs --tmpfs=/opt/elasticsearch/volatile/logs:uid=1000 --net=host --name es-it customtest
+> docker run --ulimit memlock=-1:-1 -ti --tmpfs /run --tmpfs=/opt/elasticsearch/volatile/data:uid=1000 --tmpfs=/opt/elasticsearch/volatile/logs:uid=1000 --net=host --name es-it customtest
 


### PR DESCRIPTION
For some reason the extra argument seemed to work just fine with previous Docker versions, but in 1.13.1 (Fedora 26) it leads to the following error:

/usr/bin/docker-current: Error response from daemon: invalid mount path: '--tmpfs=/opt/elasticsearch/volatile/logs' mount path must be absolute.

That's probably caused by some change in how they parse arguments.